### PR TITLE
Add optional LangSmith tracing to customer service agent

### DIFF
--- a/python/agents/customer-service/.env.example
+++ b/python/agents/customer-service/.env.example
@@ -8,3 +8,7 @@ GOOGLE_API_KEY=YOUR_VALUE_HERE #  'Google Gemini Developer API Key, required if 
 # Vertex backend config
 GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID_HERE
 GOOGLE_CLOUD_LOCATION=us-central1
+
+# Optional: Enable LangSmith tracing
+LANGCHAIN_API_KEY=
+LANGSMITH_PROJECT=customer_service

--- a/python/agents/customer-service/README.md
+++ b/python/agents/customer-service/README.md
@@ -157,7 +157,28 @@ from the root project directory:
     ```bash
     adk web
     ```
-    Select the customer_service from the dropdown
+Select the customer_service from the dropdown
+
+## Monitoring with LangSmith
+
+You can optionally trace all agent interactions and tool calls using
+[LangSmith](https://smith.langchain.com/). To enable monitoring:
+
+1. Install the `langsmith` package in your environment:
+
+   ```bash
+   poetry add langsmith
+   ```
+
+2. Set the following environment variables (for example in your `.env` file):
+
+   ```bash
+   LANGCHAIN_API_KEY=<your-api-key>
+   LANGSMITH_PROJECT=customer_service
+   ```
+
+When these values are present, the agent will send traces to your LangSmith
+project so you can inspect usage statistics and tool invocations.
 
 ### Example Interaction
 

--- a/python/agents/customer-service/customer_service/shared_libraries/__init__.py
+++ b/python/agents/customer-service/customer_service/shared_libraries/__init__.py
@@ -15,6 +15,7 @@
 from .callbacks import rate_limit_callback
 from .callbacks import before_tool
 from .callbacks import before_agent
+from .langsmith import traceable
 
 
-__all__ = ["rate_limit_callback", "before_tool", "before_agent"]
+__all__ = ["rate_limit_callback", "before_tool", "before_agent", "traceable"]

--- a/python/agents/customer-service/customer_service/shared_libraries/callbacks.py
+++ b/python/agents/customer-service/customer_service/shared_libraries/callbacks.py
@@ -24,6 +24,7 @@ from google.adk.tools import BaseTool
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.sessions.state import State
 from google.adk.tools.tool_context import ToolContext
+from .langsmith import traceable
 from jsonschema import ValidationError
 from customer_service.entities.customer import Customer
 
@@ -34,6 +35,7 @@ RATE_LIMIT_SECS = 60
 RPM_QUOTA = 10
 
 
+@traceable
 def rate_limit_callback(
     callback_context: CallbackContext, llm_request: LlmRequest
 ) -> None:
@@ -127,6 +129,7 @@ def lowercase_value(value):
 
 
 # Callback Methods
+@traceable
 def before_tool(
     tool: BaseTool, args: Dict[str, Any], tool_context: CallbackContext
 ):
@@ -161,6 +164,7 @@ def before_tool(
             return {"result": "I have added and removed the requested items."}
     return None
 
+@traceable
 def after_tool(
     tool: BaseTool, args: Dict[str, Any], tool_context: ToolContext, tool_response: Dict
 ) -> Optional[Dict]:
@@ -180,6 +184,7 @@ def after_tool(
   return None
 
 # checking that the customer profile is loaded as state.
+@traceable
 def before_agent(callback_context: InvocationContext):
     # In a production agent, this is set as part of the
     # session creation for the agent. 

--- a/python/agents/customer-service/customer_service/shared_libraries/langsmith.py
+++ b/python/agents/customer-service/customer_service/shared_libraries/langsmith.py
@@ -1,0 +1,35 @@
+"""LangSmith integration helpers.
+
+This module exposes a ``traceable`` decorator that wraps functions with
+LangSmith tracing when the ``langsmith`` package is installed and the
+``LANGCHAIN_API_KEY`` environment variable is set. If these
+requirements are not met, the decorator becomes a no-op so the rest of
+the codebase does not need to change.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+try:
+    from langsmith.run_helpers import traceable as _traceable
+    _LANGSMITH_ENABLED = bool(os.getenv("LANGCHAIN_API_KEY"))
+except Exception:  # pragma: no cover - langsmith is optional
+    _traceable = None
+    _LANGSMITH_ENABLED = False
+
+
+def traceable(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Return a decorator to trace functions with LangSmith if available."""
+
+    if _traceable is None or not _LANGSMITH_ENABLED:
+        # Fallback no-op decorator
+        def _decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return func
+
+        if args and callable(args[0]) and not kwargs:
+            return _decorator(args[0])
+        return _decorator
+
+    return _traceable(*args, **kwargs)

--- a/python/agents/customer-service/customer_service/tools/tools.py
+++ b/python/agents/customer-service/customer_service/tools/tools.py
@@ -18,10 +18,12 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 from google.adk.tools import ToolContext
+from ..shared_libraries.langsmith import traceable
 
 logger = logging.getLogger(__name__)
 
 
+@traceable
 def send_call_companion_link(phone_number: str) -> str:
     """
     Sends a link to the user's phone number to start a video session.
@@ -42,6 +44,7 @@ def send_call_companion_link(phone_number: str) -> str:
     return {"status": "success", "message": f"Link sent to {phone_number}"}
 
 
+@traceable
 def approve_discount(discount_type: str, value: float, reason: str) -> str:
     """
     Approve the flat rate or percentage discount requested by the user.
@@ -68,6 +71,7 @@ def approve_discount(discount_type: str, value: float, reason: str) -> str:
     )
     return {"status": "ok"}
 
+@traceable
 def sync_ask_for_approval(discount_type: str, value: float, reason: str) -> str:
     """
     Asks the manager for approval for a discount.
@@ -93,6 +97,7 @@ def sync_ask_for_approval(discount_type: str, value: float, reason: str) -> str:
     return {"status": "approved"}
 
 
+@traceable
 def update_salesforce_crm(customer_id: str, details: dict) -> dict:
     """
     Updates the Salesforce CRM with customer details.
@@ -121,6 +126,7 @@ def update_salesforce_crm(customer_id: str, details: dict) -> dict:
     return {"status": "success", "message": "Salesforce record updated."}
 
 
+@traceable
 def access_cart_information(customer_id: str) -> dict:
     """
     Args:
@@ -154,6 +160,7 @@ def access_cart_information(customer_id: str) -> dict:
     return mock_cart
 
 
+@traceable
 def modify_cart(
     customer_id: str, items_to_add: list[dict], items_to_remove: list[dict]
 ) -> dict:
@@ -183,6 +190,7 @@ def modify_cart(
     }
 
 
+@traceable
 def get_product_recommendations(plant_type: str, customer_id: str) -> dict:
     """Provides product recommendations based on the type of plant.
 
@@ -237,6 +245,7 @@ def get_product_recommendations(plant_type: str, customer_id: str) -> dict:
     return recommendations
 
 
+@traceable
 def check_product_availability(product_id: str, store_id: str) -> dict:
     """Checks the availability of a product at a specified store (or for pickup).
 
@@ -261,6 +270,7 @@ def check_product_availability(product_id: str, store_id: str) -> dict:
     return {"available": True, "quantity": 10, "store": store_id}
 
 
+@traceable
 def schedule_planting_service(
     customer_id: str, date: str, time_range: str, details: str
 ) -> dict:
@@ -303,6 +313,7 @@ def schedule_planting_service(
     }
 
 
+@traceable
 def get_available_planting_times(date: str) -> list:
     """Retrieves available planting service time slots for a given date.
 
@@ -322,6 +333,7 @@ def get_available_planting_times(date: str) -> list:
     return ["9-12", "13-16"]
 
 
+@traceable
 def send_care_instructions(
     customer_id: str, plant_type: str, delivery_method: str
 ) -> dict:
@@ -352,6 +364,7 @@ def send_care_instructions(
     }
 
 
+@traceable
 def generate_qr_code(
     customer_id: str,
     discount_value: float,

--- a/python/agents/customer-service/pyproject.toml
+++ b/python/agents/customer-service/pyproject.toml
@@ -18,6 +18,7 @@ google-cloud-aiplatform = { extras = [
 ], version = "^1.93.0" }
 google-adk = "^1.0.0"
 jsonschema = "^4.23.0"
+langsmith = "^0.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"


### PR DESCRIPTION
## Summary
- add optional `langsmith` dependency for customer service agent
- provide no-op `traceable` decorator and export it
- decorate callbacks and tools with `traceable`
- document LangSmith usage and env vars
- include LangSmith keys in `.env.example`

## Testing
- `pytest -q python/agents/customer-service/tests/unit/test_tools.py` *(fails: ModuleNotFoundError: No module named 'google')*