### PR TITLE
Add LangGraph wrappers and usage docs

### DIFF
--- a/python/agents/travel-concierge/README.md
+++ b/python/agents/travel-concierge/README.md
@@ -506,3 +506,13 @@ This agent sample is provided for illustrative purposes only and is not intended
 This sample has not been rigorously tested, may contain bugs or limitations, and does not include features or optimizations typically required for a production environment (e.g., robust error handling, security measures, scalability, performance considerations, comprehensive logging, or advanced configuration options).
 
 Users are solely responsible for any further development, testing, security hardening, and deployment of agents based on this sample. We recommend thorough review, testing, and the implementation of appropriate safeguards before using any derived agent in a live or critical system.
+
+## Running with LangGraph
+
+This repository also provides a minimal LangGraph wrapper around the Travel Concierge agents. Once dependencies are installed you can run it directly:
+
+```bash
+python -m travel_concierge.agent_langgraph
+```
+
+The script executes the sub‑agents sequentially and prints the final state when finished.

--- a/python/agents/travel-concierge/travel_concierge/__init__.py
+++ b/python/agents/travel-concierge/travel_concierge/__init__.py
@@ -13,3 +13,6 @@
 # limitations under the License.
 
 from . import agent
+from .agent_langgraph import root_agent_graph
+
+__all__ = ["agent", "root_agent_graph"]

--- a/python/agents/travel-concierge/travel_concierge/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/agent_langgraph.py
@@ -1,0 +1,47 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.tools.memory import _load_precreated_itinerary
+from travel_concierge.sub_agents.booking.agent_langgraph import booking_agent_graph
+from travel_concierge.sub_agents.in_trip.agent_langgraph import in_trip_agent_graph
+from travel_concierge.sub_agents.inspiration.agent_langgraph import inspiration_agent_graph
+from travel_concierge.sub_agents.planning.agent_langgraph import planning_agent_graph
+from travel_concierge.sub_agents.post_trip.agent_langgraph import post_trip_agent_graph
+from travel_concierge.sub_agents.pre_trip.agent_langgraph import pre_trip_agent_graph
+
+
+def _load_itinerary(state: dict) -> dict:
+    """Load precreated itinerary into the session state."""
+    _load_precreated_itinerary(state)
+    return state
+
+
+def build_root_graph() -> StateGraph:
+    """Construct the travel concierge graph using LangGraph."""
+    builder = StateGraph(dict)
+
+    builder.add_node("load_itinerary", _load_itinerary)
+    builder.add_node("inspiration_agent", inspiration_agent_graph)
+    builder.add_node("planning_agent", planning_agent_graph)
+    builder.add_node("booking_agent", booking_agent_graph)
+    builder.add_node("pre_trip_agent", pre_trip_agent_graph)
+    builder.add_node("in_trip_agent", in_trip_agent_graph)
+    builder.add_node("post_trip_agent", post_trip_agent_graph)
+
+    builder.set_entry_point("load_itinerary")
+    builder.add_edge("load_itinerary", "inspiration_agent")
+    builder.add_edge("inspiration_agent", "planning_agent")
+    builder.add_edge("planning_agent", "booking_agent")
+    builder.add_edge("booking_agent", "pre_trip_agent")
+    builder.add_edge("pre_trip_agent", "in_trip_agent")
+    builder.add_edge("in_trip_agent", "post_trip_agent")
+    builder.add_edge("post_trip_agent", END)
+
+    return builder.compile()
+
+
+root_agent_graph = build_root_graph()
+
+
+if __name__ == "__main__":
+    result = root_agent_graph.invoke({})
+    print(result)

--- a/python/agents/travel-concierge/travel_concierge/shared_libraries/langgraph_utils.py
+++ b/python/agents/travel-concierge/travel_concierge/shared_libraries/langgraph_utils.py
@@ -1,0 +1,30 @@
+"""Helper utilities for LangGraph wrappers."""
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+
+def agent_invoker(agent: Any) -> Callable[[dict], Any]:
+    """Return a callable that executes the given ADK agent.
+
+    The returned function tries common method names like ``invoke`` or ``run``
+    and falls back to calling the agent directly if it is callable.
+    """
+
+    async def _run(state: dict):
+        for name in ("invoke_async", "invoke", "run_async", "run"):
+            if hasattr(agent, name):
+                fn = getattr(agent, name)
+                result = fn(state)
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+        if callable(agent):
+            result = agent(state)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        raise AttributeError(f"Agent {agent!r} is not callable")
+
+    return _run

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/booking/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/booking/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.shared_libraries.langgraph_utils import agent_invoker
+from .agent import booking_agent
+
+
+def build_booking_graph() -> StateGraph:
+    """Wrap the booking agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("booking_agent", agent_invoker(booking_agent))
+    builder.set_entry_point("booking_agent")
+    builder.add_edge("booking_agent", END)
+    return builder.compile()
+
+
+booking_agent_graph = build_booking_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/in_trip/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/in_trip/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.shared_libraries.langgraph_utils import agent_invoker
+from .agent import in_trip_agent
+
+
+def build_in_trip_graph() -> StateGraph:
+    """Wrap the in trip agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("in_trip_agent", agent_invoker(in_trip_agent))
+    builder.set_entry_point("in_trip_agent")
+    builder.add_edge("in_trip_agent", END)
+    return builder.compile()
+
+
+in_trip_agent_graph = build_in_trip_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/inspiration/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/inspiration/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.shared_libraries.langgraph_utils import agent_invoker
+from .agent import inspiration_agent
+
+
+def build_inspiration_graph() -> StateGraph:
+    """Wrap the inspiration agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("inspiration_agent", agent_invoker(inspiration_agent))
+    builder.set_entry_point("inspiration_agent")
+    builder.add_edge("inspiration_agent", END)
+    return builder.compile()
+
+
+inspiration_agent_graph = build_inspiration_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/planning/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/planning/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.shared_libraries.langgraph_utils import agent_invoker
+from .agent import planning_agent
+
+
+def build_planning_graph() -> StateGraph:
+    """Wrap the planning agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("planning_agent", agent_invoker(planning_agent))
+    builder.set_entry_point("planning_agent")
+    builder.add_edge("planning_agent", END)
+    return builder.compile()
+
+
+planning_agent_graph = build_planning_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/post_trip/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/post_trip/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.shared_libraries.langgraph_utils import agent_invoker
+from .agent import post_trip_agent
+
+
+def build_post_trip_graph() -> StateGraph:
+    """Wrap the post trip agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("post_trip_agent", agent_invoker(post_trip_agent))
+    builder.set_entry_point("post_trip_agent")
+    builder.add_edge("post_trip_agent", END)
+    return builder.compile()
+
+
+post_trip_agent_graph = build_post_trip_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/pre_trip/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/pre_trip/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.shared_libraries.langgraph_utils import agent_invoker
+from .agent import pre_trip_agent
+
+
+def build_pre_trip_graph() -> StateGraph:
+    """Wrap the pre trip agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("pre_trip_agent", agent_invoker(pre_trip_agent))
+    builder.set_entry_point("pre_trip_agent")
+    builder.add_edge("pre_trip_agent", END)
+    return builder.compile()
+
+
+pre_trip_agent_graph = build_pre_trip_graph()


### PR DESCRIPTION
## Summary
- fix langgraph wrappers to call agents generically
- expose `root_agent_graph` in the travel concierge package
- provide minimal entrypoint in `agent_langgraph.py`
- document running the LangGraph script in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*
