### PR TITLE
Add LangGraph utilities and README instructions

### DIFF
--- a/python/agents/travel-concierge/README.md
+++ b/python/agents/travel-concierge/README.md
@@ -221,6 +221,22 @@ Instead of interacting with the concierge one turn at time. Try giving it the en
 Without specifically optimizing for such usage, this cohort of agents seem to be able to operate by themselves on your behalf with very little input.
 
 
+### Running with LangGraph
+
+In addition to the ADK workflow, the travel concierge can also be executed using
+the [LangGraph](https://python.langchain.com/docs/langgraph/) library. This
+wrapper stitches the same sub-agents together in a simple graph.
+
+To run the LangGraph version directly:
+
+```bash
+python -m travel_concierge.agent_langgraph
+```
+
+The command loads the sample itinerary specified in `.env` and executes the
+graph once, printing the resulting session state.
+
+
 ## Running Tests
 
 To run the illustrative tests and evaluations, install the extra dependencies and run `pytest`:

--- a/python/agents/travel-concierge/travel_concierge/__init__.py
+++ b/python/agents/travel-concierge/travel_concierge/__init__.py
@@ -13,3 +13,6 @@
 # limitations under the License.
 
 from . import agent
+from .agent_langgraph import root_agent_graph
+
+__all__ = ["agent", "root_agent_graph"]

--- a/python/agents/travel-concierge/travel_concierge/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/agent_langgraph.py
@@ -1,0 +1,56 @@
+from langgraph.graph import StateGraph, END
+
+from travel_concierge.tools.memory import _load_precreated_itinerary
+from travel_concierge.sub_agents.booking.agent_langgraph import booking_agent_graph
+from travel_concierge.sub_agents.in_trip.agent_langgraph import in_trip_agent_graph
+from travel_concierge.sub_agents.inspiration.agent_langgraph import inspiration_agent_graph
+from travel_concierge.sub_agents.planning.agent_langgraph import planning_agent_graph
+from travel_concierge.sub_agents.post_trip.agent_langgraph import post_trip_agent_graph
+from travel_concierge.sub_agents.pre_trip.agent_langgraph import pre_trip_agent_graph
+
+
+class _CallbackContextWrapper:
+    """Minimal adapter providing a ``state`` attribute for memory helpers."""
+
+    def __init__(self, state: dict):
+        self.state = state
+
+
+def _load_itinerary(state: dict) -> dict:
+    """Load a precreated itinerary into the session state."""
+    ctx = _CallbackContextWrapper(state)
+    _load_precreated_itinerary(ctx)
+    return state
+
+
+def build_root_graph() -> StateGraph:
+    """Construct the travel concierge workflow using LangGraph."""
+    builder = StateGraph(dict)
+
+    builder.add_node("load_itinerary", _load_itinerary)
+    builder.add_node("inspiration_agent", inspiration_agent_graph)
+    builder.add_node("planning_agent", planning_agent_graph)
+    builder.add_node("booking_agent", booking_agent_graph)
+    builder.add_node("pre_trip_agent", pre_trip_agent_graph)
+    builder.add_node("in_trip_agent", in_trip_agent_graph)
+    builder.add_node("post_trip_agent", post_trip_agent_graph)
+
+    builder.set_entry_point("load_itinerary")
+    builder.add_edge("load_itinerary", "inspiration_agent")
+    builder.add_edge("inspiration_agent", "planning_agent")
+    builder.add_edge("planning_agent", "booking_agent")
+    builder.add_edge("booking_agent", "pre_trip_agent")
+    builder.add_edge("pre_trip_agent", "in_trip_agent")
+    builder.add_edge("in_trip_agent", "post_trip_agent")
+    builder.add_edge("post_trip_agent", END)
+
+    return builder.compile()
+
+
+root_agent_graph = build_root_graph()
+
+
+if __name__ == "__main__":
+    # Execute the graph once and print the resulting state.
+    final_state = root_agent_graph.invoke({})
+    print(final_state)

--- a/python/agents/travel-concierge/travel_concierge/langgraph_utils.py
+++ b/python/agents/travel-concierge/travel_concierge/langgraph_utils.py
@@ -1,0 +1,25 @@
+"""Utility helpers for LangGraph wrappers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable
+
+
+def agent_invoker(agent: Any) -> Callable[[dict], dict]:
+    """Return a callable that executes an ADK agent with the given state.
+
+    The ADK agents expose different invocation methods. This helper tries to
+    call ``invoke`` if present, otherwise ``run`` or ``run_async``.
+    """
+
+    def _invoke(state: dict) -> dict:
+        if hasattr(agent, "invoke"):
+            return agent.invoke(state)
+        if hasattr(agent, "run"):
+            return agent.run(state)
+        if hasattr(agent, "run_async"):
+            return asyncio.run(agent.run_async(state))
+        raise AttributeError(f"{type(agent).__name__} has no callable interface")
+
+    return _invoke

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/booking/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/booking/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from .agent import booking_agent
+from travel_concierge.langgraph_utils import agent_invoker
+
+
+def build_booking_graph() -> StateGraph:
+    """Wrap the booking agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("booking_agent", agent_invoker(booking_agent))
+    builder.set_entry_point("booking_agent")
+    builder.add_edge("booking_agent", END)
+    return builder.compile()
+
+
+booking_agent_graph = build_booking_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/in_trip/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/in_trip/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from .agent import in_trip_agent
+from travel_concierge.langgraph_utils import agent_invoker
+
+
+def build_in_trip_graph() -> StateGraph:
+    """Wrap the in trip agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("in_trip_agent", agent_invoker(in_trip_agent))
+    builder.set_entry_point("in_trip_agent")
+    builder.add_edge("in_trip_agent", END)
+    return builder.compile()
+
+
+in_trip_agent_graph = build_in_trip_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/inspiration/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/inspiration/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from .agent import inspiration_agent
+from travel_concierge.langgraph_utils import agent_invoker
+
+
+def build_inspiration_graph() -> StateGraph:
+    """Wrap the inspiration agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("inspiration_agent", agent_invoker(inspiration_agent))
+    builder.set_entry_point("inspiration_agent")
+    builder.add_edge("inspiration_agent", END)
+    return builder.compile()
+
+
+inspiration_agent_graph = build_inspiration_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/planning/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/planning/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from .agent import planning_agent
+from travel_concierge.langgraph_utils import agent_invoker
+
+
+def build_planning_graph() -> StateGraph:
+    """Wrap the planning agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("planning_agent", agent_invoker(planning_agent))
+    builder.set_entry_point("planning_agent")
+    builder.add_edge("planning_agent", END)
+    return builder.compile()
+
+
+planning_agent_graph = build_planning_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/post_trip/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/post_trip/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from .agent import post_trip_agent
+from travel_concierge.langgraph_utils import agent_invoker
+
+
+def build_post_trip_graph() -> StateGraph:
+    """Wrap the post trip agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("post_trip_agent", agent_invoker(post_trip_agent))
+    builder.set_entry_point("post_trip_agent")
+    builder.add_edge("post_trip_agent", END)
+    return builder.compile()
+
+
+post_trip_agent_graph = build_post_trip_graph()

--- a/python/agents/travel-concierge/travel_concierge/sub_agents/pre_trip/agent_langgraph.py
+++ b/python/agents/travel-concierge/travel_concierge/sub_agents/pre_trip/agent_langgraph.py
@@ -1,0 +1,16 @@
+from langgraph.graph import StateGraph, END
+
+from .agent import pre_trip_agent
+from travel_concierge.langgraph_utils import agent_invoker
+
+
+def build_pre_trip_graph() -> StateGraph:
+    """Wrap the pre trip agent into a LangGraph graph."""
+    builder = StateGraph(dict)
+    builder.add_node("pre_trip_agent", agent_invoker(pre_trip_agent))
+    builder.set_entry_point("pre_trip_agent")
+    builder.add_edge("pre_trip_agent", END)
+    return builder.compile()
+
+
+pre_trip_agent_graph = build_pre_trip_graph()


### PR DESCRIPTION
## Summary
- add `langgraph_utils.agent_invoker` to call ADK agents
- fix itinerary loader for LangGraph workflow
- expose `root_agent_graph` from package
- update LangGraph wrappers to use generic invoker
- document how to run the LangGraph version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*
