### PR TITLE
Fix async agent invocation

### DIFF
--- a/python/agents/travel-concierge/travel_concierge/langgraph_utils.py
+++ b/python/agents/travel-concierge/travel_concierge/langgraph_utils.py
@@ -3,23 +3,52 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from typing import Any, Callable
 
 
 def agent_invoker(agent: Any) -> Callable[[dict], dict]:
     """Return a callable that executes an ADK agent with the given state.
 
-    The ADK agents expose different invocation methods. This helper tries to
-    call ``invoke`` if present, otherwise ``run`` or ``run_async``.
+    The returned function attempts common entrypoints like ``invoke_async`` or
+    ``invoke`` before falling back to ``run_async`` or ``run``.  It supports
+    coroutines and async generators, returning their final result synchronously.
     """
 
+    async def _consume_async_gen(agen):
+        """Iterate an async generator and return the last yielded value."""
+        result = None
+        async for item in agen:
+            result = item
+        return result
+
     def _invoke(state: dict) -> dict:
-        if hasattr(agent, "invoke"):
-            return agent.invoke(state)
-        if hasattr(agent, "run"):
-            return agent.run(state)
-        if hasattr(agent, "run_async"):
-            return asyncio.run(agent.run_async(state))
-        raise AttributeError(f"{type(agent).__name__} has no callable interface")
+        """Invoke ``agent`` using common method names.
+
+        Handles sync callables, coroutines and async generators. If the agent
+        exposes ``invoke_async``/``invoke``/``run_async``/``run`` methods they
+        are tried in this order. Otherwise the agent is called directly if
+        callable.
+        """
+
+        for name in ("invoke_async", "invoke", "run_async", "run"):
+            if hasattr(agent, name):
+                fn = getattr(agent, name)
+                result = fn(state)
+                if inspect.isawaitable(result):
+                    return asyncio.run(result)
+                if hasattr(result, "__aiter__"):
+                    return asyncio.run(_consume_async_gen(result))
+                return result
+
+        if callable(agent):
+            result = agent(state)
+            if inspect.isawaitable(result):
+                return asyncio.run(result)
+            if hasattr(result, "__aiter__"):
+                return asyncio.run(_consume_async_gen(result))
+            return result
+
+        raise AttributeError(f"Agent {agent!r} is not callable")
 
     return _invoke


### PR DESCRIPTION
## Summary
- improve `agent_invoker` logic for ADK agents
  - support invoke_async/run_async coroutines and async generators
  - fall back to calling the agent directly when needed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google', 'dotenv', 'vertexai')*